### PR TITLE
Add auto-advance to next chapter when audio finishes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ A Reactive Bible App developed with Reactjs & Mantine. Features include:
 - Bible verse scroll-to-view feature.
 - Offline Bible passages.
 - Online Audio Bible.
+- Verse tagging.
 - Book, Chapter & Verse Navigation.
-- Prev & Next Chapter navigation. 
+- Prev & Next Chapter navigation.
 - Detailed tests included using react testing library and vitest.
 - And lots more.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ A Reactive Bible App developed with Reactjs & Mantine. Features include:
 - Verse tagging.
 - Book, Chapter & Verse Navigation.
 - Prev & Next Chapter navigation.
+- Available translations:
+    - KJV
+    - ESV
 - Detailed tests included using react testing library and vitest.
 - And lots more.
 
@@ -40,5 +43,25 @@ npm run dev
 # or
 yarn dev
 ```
+
+## Contribution
+1. Fork the repository
+2. Create a new branch
+3. Commit your changes
+4. Ensure all tests pass by running:
+    - `npm run test`
+    - `npm run build`
+4. Create a pull request
+
+### Keep your fork up to date with the main branch
+1. Add the original repository as a remote:
+    - `git remote add upstream https://github.com/realvincentuche/reactive-bible.git`
+2. Fetch the latest changes from the upstream repository:
+    - `git fetch upstream`
+3. Merge the latest changes into your local main branch:
+    - `git checkout main`
+    - `git merge upstream/main`
+4. Push the updated main branch to your fork:
+    - `git push origin main`
 
 Your feedback and contributions are welcome!

--- a/src/api.tsx
+++ b/src/api.tsx
@@ -81,3 +81,29 @@ export const getPassage = (): {
     chapter: number;
   }[];
 };
+
+export const addTagNote = async (
+  tagId: string,
+  tagNoteText: string,
+  verseReferences: { book: string; chapter: number; verse: number }[]
+) => {
+  const body = JSON.stringify({
+    tag: tagId,
+    note_text: tagNoteText,
+    verse_references: verseReferences,
+  })
+
+  try {
+    const response = await fetch('https://bible-research.vercel.app/api/v1/notes/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: body,
+    });
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/api.tsx
+++ b/src/api.tsx
@@ -1,8 +1,11 @@
 import bibleJson from "./assets/kjv.json";
+/**
+ * Interface for the locally stored KJV Bible data.
+ * Note: ESV Bible data is not stored locally but fetched from an external API when needed.
+ */
+export const data = bibleJson as KjvBook[];
 
-export const data = bibleJson as Book[];
-
-export interface Book {
+export interface KjvBook {
   chapter: number;
   verse: number;
   text: string;
@@ -13,7 +16,7 @@ export interface Book {
 
 export const getBooks = (): { book_name: string; book_id: string }[] => {
   const set = new Set<string>();
-  data.map((book: Book) => {
+  data.map((book: KjvBook) => {
     const obj = {
       book_name: book.book_name,
       book_id: book.book_id,
@@ -33,8 +36,8 @@ export const getChapters = (thebook: string): number[] => {
   return [
     ...new Set<number>(
       data
-        .filter((book: Book) => book.book_name === thebook)
-        .map((book: Book) => book.chapter)
+        .filter((book: KjvBook) => book.book_name === thebook)
+        .map((book: KjvBook) => book.chapter)
     ),
   ];
 };
@@ -42,20 +45,59 @@ export const getChapters = (thebook: string): number[] => {
 export const getVerses = (thebook: string, thechapter: number): number[] => {
   return data
     .filter(
-      (book: Book) => book.book_name === thebook && book.chapter === thechapter
+      (book: KjvBook) => book.book_name === thebook && book.chapter === thechapter
     )
-    .map((book: Book) => book.verse);
+    .map((book: KjvBook) => book.verse);
 };
 
-export const getVersesInChapter = (
+export const getVersesInChapter = async (
+  thebook: string,
+  thechapter: number,
+  bibleVersion: string
+): Promise<{ verse: number; text: string }[]> => {
+  if (bibleVersion === 'KJV') {
+    return getVersesInKjvChapter(thebook, thechapter);
+  } else if (bibleVersion === 'ESV') {
+    return await getVersesInEsvChapter(thebook, thechapter);
+  } else {
+    throw new Error(`Unsupported Bible version: ${bibleVersion}`);
+  }
+};
+
+export const getVersesInKjvChapter = (
   thebook: string,
   thechapter: number
 ): { verse: number; text: string }[] => {
   return data
     .filter(
-      (book: Book) => book.book_name === thebook && book.chapter === thechapter
+      (book: KjvBook) => book.book_name === thebook && book.chapter === thechapter
     )
-    .map((book: Book) => ({ verse: book.verse, text: book.text }));
+    .map((book: KjvBook) => ({ verse: book.verse, text: book.text }));
+};
+
+export const getVersesInEsvChapter = async (
+  thebook: string,
+  thechapter: number
+): Promise<{ verse: number; text: string }[]> => {
+  try {
+    const passage = `${thebook} ${thechapter}`;
+    const url = `https://bible-research.vercel.app/api/v1/bible?passage=${passage}`;
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    const data = await response.json();
+
+    const verses = data.verses
+    return Promise.resolve(verses.map((verse: { verse: number; text: string }) => ({
+      verse: verse.verse, text: verse.text
+    })));  } catch (error) {
+    console.error(error);
+    throw error;
+  }
 };
 
 export const getPassage = (): {
@@ -64,7 +106,7 @@ export const getPassage = (): {
   chapter: number;
 }[] => {
   const set = new Set<string>();
-  data.map((book: Book) => {
+  data.map((book: KjvBook) => {
     const obj = {
       book_name: book.book_name,
       book_id: book.book_id,

--- a/src/api.tsx
+++ b/src/api.tsx
@@ -149,3 +149,36 @@ export const addTagNote = async (
     console.error(error);
   }
 };
+
+export interface NoteVerse {
+  book: string;
+  chapter: number;
+  verse: number;
+  text: string;
+}
+
+export interface Tag {
+  id: string;
+  name: string;
+  parent_tag: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Note {
+  id: string;
+  note_text: string;
+  public: boolean;
+  created_at: string;
+  updated_at: string;
+  tag: Tag;
+  verses: NoteVerse[];
+}
+
+export const getNotes = async (): Promise<Note[]> => {
+  const response = await fetch(
+    'https://bible-research.vercel.app/api/v1/notes/'
+  );
+  if (!response.ok) throw new Error('Failed to fetch notes');
+  return await response.json();
+};

--- a/src/components/AddTagNoteModal.tsx
+++ b/src/components/AddTagNoteModal.tsx
@@ -1,0 +1,102 @@
+import { Modal, Button, Select, TextInput } from "@mantine/core";
+import { addTagNote } from "../api";
+import { useBibleStore } from "../store";
+import { useState, useEffect } from "react";
+
+interface AddTagNoteModalProps {
+  opened: boolean;
+  onClose: () => void;
+}
+
+const AddTagNoteModal = ({ opened, onClose }: AddTagNoteModalProps) => {
+  const [tags, setTags] = useState<{ id: string; name: string; key: number }[]>([]);
+  const [selectedTagId, setSelectedTagId] = useState("");
+  const [selectedTagName, setSelectedTagName] = useState("");
+  const [tagNoteText, setTagNoteText] = useState("");
+  const activeVerses = useBibleStore((state) => state.activeVerses);
+  const activeBook = useBibleStore((state) => state.activeBook);
+  const activeChapter = useBibleStore((state) => state.activeChapter);
+
+  useEffect(() => {
+    const fetchTags = async () => {
+      try {
+        const response = await fetch(
+          "https://bible-research.vercel.app/api/v1/tags/"
+        );
+        const data = await response.json();
+        setTags(
+          data.map((item: { id: any; name: any; }, index: any) => ({
+            id: item.id,
+            name: item.name,
+            key: index,
+          }))
+        );
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    fetchTags();
+  }, []);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const verseReferences = activeVerses.map((verse) => ({
+      book: activeBook,
+      chapter: activeChapter,
+      verse,
+    }));
+    try {
+      const data = await addTagNote(
+        selectedTagId,
+        tagNoteText,
+        verseReferences
+      );
+      console.log("Tag note added:", data);
+      onClose();
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return (
+    <Modal
+      variant="transparent"
+      opened={opened}
+      onClose={onClose}
+      title="Add note"
+    >
+      <form onSubmit={handleSubmit}>
+        <Select
+          variant="transparent"
+          label="Tag"
+          value={selectedTagName}
+          onChange={(item: string) => {
+            const tagId = tags.find((tag) => tag.name === item)?.id;
+            setSelectedTagId(tagId ?? '');
+            setSelectedTagName(item);
+          }}
+          data={tags.map((tag) => tag.name)}
+        />
+        <TextInput
+          variant="transparent"
+          label="Note"
+          value={tagNoteText}
+          onChange={(event) => setTagNoteText(event.currentTarget.value)}
+        />
+        <Button variant="transparent" type="submit">
+          Submit
+        </Button>
+        <Button
+          variant="transparent"
+          onClick={() => window.open('https://bible-research.vercel.app/api/v1/tags/', '_blank')}
+          style={{ width: '100%' }}
+        >
+          Or create a new tag
+        </Button>
+      </form>
+    </Modal>
+  );
+};
+
+export default AddTagNoteModal;

--- a/src/components/Audio.tsx
+++ b/src/components/Audio.tsx
@@ -1,49 +1,126 @@
 import { useState, useEffect } from "react";
 import { Howl } from "howler";
 import { useBibleStore } from "../store";
-import { getBooks } from "../api";
-import { ActionIcon, rem } from "@mantine/core";
+import { getKjvAudioUrl, getBibleAudioUrl } from "../api";
+import { ActionIcon, rem, Loader } from "@mantine/core";
 import { IconPlayerPlay, IconPlayerStop } from "@tabler/icons-react";
 
 const Audio = () => {
   const [isPlaying, setIsPlaying] = useState(false);
   const [audio, setAudio] = useState<Howl | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const activeBook = useBibleStore((state) => state.activeBook);
   const activeChapter = useBibleStore((state) => state.activeChapter);
+  const bibleVersion = useBibleStore((state) => state.bibleVersion);
 
   useEffect(() => {
-    if (isPlaying) {
-      if (audio !== null) audio.stop();
-      const index = getBooks().findIndex(
-        (book) => book.book_name === activeBook
-      );
-      const audioHowl = new Howl({
-        src: [
-          `https://wordpocket.org/bibles/app/audio/1/${
-            index + 1
-          }/${activeChapter}.mp3`,
-        ],
-        html5: true,
-        pool: 1,
-        onplay: () => setIsPlaying(true),
-        onpause: () => setIsPlaying(false),
-        onend: () => setIsPlaying(false),
-      });
-      setAudio(audioHowl);
-      audioHowl.play();
-    } else audio?.stop();
+    const loadAndPlayAudio = async () => {
+      if (isPlaying) {
+        // Stop any currently playing audio
+        if (audio !== null) {
+          audio.stop();
+          audio.unload();
+        }
 
+        setLoading(true);
+        setError(null);
+
+        try {
+          let audioUrl: string;
+
+          // KJV uses wordpocket.org (instant URL)
+          if (bibleVersion === 'KJV') {
+            audioUrl = getKjvAudioUrl(activeBook, activeChapter);
+          }
+          // All other translations use Bible Research API
+          else {
+            audioUrl = await getBibleAudioUrl(
+              activeBook,
+              activeChapter,
+              bibleVersion
+            );
+          }
+
+          // Validate audio URL
+          if (!audioUrl || typeof audioUrl !== 'string') {
+            throw new Error(
+              `Invalid audio URL: ${audioUrl} for ${bibleVersion}`
+            );
+          }
+
+          // Create and play audio
+          const audioHowl = new Howl({
+            src: [audioUrl],
+            html5: true,
+            pool: 1,
+            onplay: () => {
+              setIsPlaying(true);
+              setLoading(false);
+            },
+            onpause: () => setIsPlaying(false),
+            onend: () => setIsPlaying(false),
+            onloaderror: (_id, err) => {
+              console.error('Audio load error:', err);
+              setError('Failed to load audio');
+              setIsPlaying(false);
+              setLoading(false);
+            },
+            onplayerror: (_id, err) => {
+              console.error('Audio play error:', err);
+              setError('Failed to play audio');
+              setIsPlaying(false);
+              setLoading(false);
+            },
+          });
+
+          setAudio(audioHowl);
+          audioHowl.play();
+        } catch (err) {
+          console.error('Error loading audio:', err);
+          
+          // Extract user-friendly error message
+          let errorMsg = 'Audio unavailable';
+          if (err instanceof Error) {
+            // Extract just the key part of the error
+            if (err.message.includes('not available')) {
+              errorMsg = 'Audio not available';
+            } else if (err.message.includes('No Fileset')) {
+              errorMsg = 'Audio not available for this chapter';
+            } else {
+              errorMsg = err.message.split(':')[0]; // Get first part
+            }
+          }
+          
+          setError(errorMsg);
+          setIsPlaying(false);
+          setLoading(false);
+        }
+      } else {
+        // Stop audio
+        audio?.stop();
+        setLoading(false);
+      }
+    };
+
+    loadAndPlayAudio();
+
+    // Cleanup on unmount or when dependencies change
     return () => {
       audio?.unload();
     };
-  }, [activeBook, activeChapter, isPlaying]);
+  }, [activeBook, activeChapter, bibleVersion, isPlaying]);
 
   return (
     <ActionIcon
       variant="transparent"
       onClick={() => setIsPlaying((value) => !value)}
+      disabled={loading}
+      title={error || (isPlaying ? "Stop audio" : "Play audio")}
     >
-      {isPlaying ? (
+      {loading ? (
+        <Loader size={rem(20)} />
+      ) : isPlaying ? (
         <IconPlayerStop size={rem(20)} />
       ) : (
         <IconPlayerPlay size={rem(20)} />

--- a/src/components/BibleVersionToggle.tsx
+++ b/src/components/BibleVersionToggle.tsx
@@ -1,0 +1,24 @@
+import { Button, useMantineTheme } from '@mantine/core';
+import { useBibleStore } from '../store';
+
+export function BibleVersionToggle() {
+  const { bibleVersion, setBibleVersion } = useBibleStore((state) => ({
+    bibleVersion: state.bibleVersion,
+    setBibleVersion: state.setBibleVersion,
+  }));
+  const theme = useMantineTheme();
+
+  const handleBibleVersionChange = () => {
+    setBibleVersion(bibleVersion === 'KJV' ? 'ESV' : 'KJV');
+  };
+
+  return (
+    <Button
+      variant="outline"
+      color={theme.colorScheme === 'dark' ? 'dark' : 'gray'}
+      onClick={handleBibleVersionChange}
+    >
+      {bibleVersion === 'KJV' ? 'KJV' : 'ESV'}
+    </Button>
+  );
+}

--- a/src/components/MyHeader.tsx
+++ b/src/components/MyHeader.tsx
@@ -12,6 +12,7 @@ import {
   useMantineTheme,
 } from "@mantine/core";
 import { IconMoonStars, IconSun } from "@tabler/icons-react";
+import { BibleVersionToggle } from './BibleVersionToggle';
 import { SearchControl } from "./SearchControl";
 
 const MyHeader = ({
@@ -65,6 +66,7 @@ const MyHeader = ({
             Reactive Bible
           </Title>
         </Flex>
+        <BibleVersionToggle />
         <MediaQuery smallerThan="sm" styles={{ display: "none" }}>
           <SearchControl onClick={open} />
         </MediaQuery>

--- a/src/components/MyNavbar.tsx
+++ b/src/components/MyNavbar.tsx
@@ -55,11 +55,11 @@ const MyNavbar = ({
   const { classes, cx } = useStyles();
   const activeBook = useBibleStore((state) => state.activeBook);
   const activeChapter = useBibleStore((state) => state.activeChapter);
-  const activeVerse = useBibleStore((state) => state.activeVerse);
+  const activeVerses = useBibleStore((state) => state.activeVerses);
   const setActiveBook = useBibleStore((state) => state.setActiveBook);
   const setActiveBookShort = useBibleStore((state) => state.setActiveBookShort);
   const setActiveChapter = useBibleStore((state) => state.setActiveChapter);
-  const setActiveVerse = useBibleStore((state) => state.setActiveVerse);
+  const setActiveVerses = useBibleStore((state) => state.setActiveVerses);
 
   return (
     <Navbar
@@ -119,12 +119,12 @@ const MyNavbar = ({
             {getVerses(activeBook, activeChapter).map((verse) => (
               <a
                 className={cx(classes.link, {
-                  [classes.linkActive]: activeVerse === verse,
+                  [classes.linkActive]: activeVerses.includes(verse),
                 })}
                 href="/"
                 onClick={(event) => {
                   event.preventDefault();
-                  setActiveVerse(verse);
+                  setActiveVerses([verse]);
                   setOpened(false);
                 }}
                 key={verse}

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -1,0 +1,57 @@
+import { Card, Title, Text, Button, Group, Box } from "@mantine/core";
+import { Note } from "../api";
+import Verse from "./Verse";
+
+interface NoteCardProps {
+  note: Note;
+  onViewInBible: (book: string, chapter: number, verse: number) => void;
+}
+
+const NoteCard = ({ note, onViewInBible }: NoteCardProps) => {
+  const firstVerse = note.verses[0]?.verse || 1;
+  const lastVerse = note.verses[note.verses.length - 1]?.verse || 1;
+  const book = note.verses[0]?.book || "";
+  const chapter = note.verses[0]?.chapter || 1;
+
+  const heading =
+    firstVerse === lastVerse
+      ? `${book} ${chapter}:${firstVerse}`
+      : `${book} ${chapter}:${firstVerse}-${lastVerse}`;
+
+  return (
+    <Card shadow="sm" padding={0} radius="md" mb={15}>
+      <Group position="apart" mb={10}>
+        <Title order={4}>{heading}</Title>
+        <Button
+          variant="subtle"
+          size="xs"
+          onClick={() => onViewInBible(book, chapter, firstVerse)}
+        >
+          View in Bible
+        </Button>
+      </Group>
+
+      {note.verses.map((v) => (
+        <Verse key={v.verse} verse={v.verse} text={v.text} />
+      ))}
+
+      <Box
+        mt={10}
+        p={10}
+        sx={(theme) => ({
+          backgroundColor:
+            theme.colorScheme === "dark"
+              ? theme.colors.dark[4]
+              : theme.colors.gray[4],
+          borderRadius: theme.radius.sm,
+        })}
+      >
+        <Text fs="italic">
+          {note.note_text}
+        </Text>
+      </Box>
+    </Card>
+  );
+};
+
+export default NoteCard;

--- a/src/components/NotesView.tsx
+++ b/src/components/NotesView.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from "react";
+import { ScrollArea, Box, Loader, Text, Center, Select, Group } from "@mantine/core";
+import { getNotes, Note } from "../api";
+import TagSection from "./TagSection";
+
+interface NotesViewProps {
+  onViewInBible: (book: string, chapter: number, verse: number) => void;
+}
+
+const NotesView = ({ onViewInBible }: NotesViewProps) => {
+  const [notes, setNotes] = useState<Note[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedTag, setSelectedTag] = useState<string | null>(null);
+
+  useEffect(() => {
+    getNotes()
+      .then((data) => {
+        setNotes(data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err.message);
+        setLoading(false);
+      });
+  }, []);
+
+  // Extract unique tags and sort alphabetically
+  const uniqueTags = Array.from(
+    new Set(notes.map((note) => note.tag.name))
+  ).sort();
+
+  // Filter notes by selected tag
+  const filteredNotes = selectedTag
+    ? notes.filter((note) => note.tag.name === selectedTag)
+    : notes;
+
+  // Group filtered notes by tag name
+  const groupedNotes = filteredNotes.reduce((acc, note) => {
+    const tagName = note.tag.name;
+    if (!acc[tagName]) {
+      acc[tagName] = [];
+    }
+    acc[tagName].push(note);
+    return acc;
+  }, {} as Record<string, Note[]>);
+
+  if (loading) {
+    return (
+      <Center h="80vh">
+        <Loader size="lg" />
+      </Center>
+    );
+  }
+
+  if (error) {
+    return (
+      <Center h="80vh">
+        <Text c="red">Error loading notes: {error}</Text>
+      </Center>
+    );
+  }
+
+  if (notes.length === 0) {
+    return (
+      <Center h="80vh">
+        <Text c="dimmed">No notes yet. Create your first note!</Text>
+      </Center>
+    );
+  }
+
+  return (
+    <ScrollArea h="80vh">
+      <Box>
+        {/* Tag Filter Dropdown */}
+        <Box mb={20} px={10}>
+          <Group spacing="xs">
+            <Text size="sm" weight={500}>
+              Filter by Tag:
+            </Text>
+            <Select
+              value={selectedTag}
+              onChange={setSelectedTag}
+              data={[
+                { value: '', label: 'All Tags' },
+                ...uniqueTags.map((tag) => ({ value: tag, label: tag })),
+              ]}
+              placeholder="All Tags"
+              size="sm"
+              style={{ minWidth: 150 }}
+            />
+          </Group>
+        </Box>
+
+        {/* Notes Display */}
+        {Object.keys(groupedNotes).length === 0 ? (
+          <Center h="60vh">
+            <Text c="dimmed">No notes found for this tag.</Text>
+          </Center>
+        ) : (
+          Object.entries(groupedNotes).map(([tagName, tagNotes]) => (
+            <TagSection
+              key={tagName}
+              tagName={tagName}
+              notes={tagNotes}
+              onViewInBible={onViewInBible}
+            />
+          ))
+        )}
+      </Box>
+    </ScrollArea>
+  );
+};
+
+export default NotesView;

--- a/src/components/Passage.tsx
+++ b/src/components/Passage.tsx
@@ -1,7 +1,7 @@
 import { useBibleStore } from "../store";
 import { getVersesInChapter } from "../api";
 import { Box, ScrollArea } from "@mantine/core";
-import { useRef } from "react";
+import { useState, useEffect, useRef } from "react";
 import SubHeader from "./SubHeader";
 import Verse from "./Verse";
 
@@ -9,6 +9,15 @@ const Passage = ({ open }: { open: () => void  }) => {
   const viewport = useRef<HTMLDivElement>(null);
   const activeBook = useBibleStore((state) => state.activeBook);
   const activeChapter = useBibleStore((state) => state.activeChapter);
+  const bibleVersion = useBibleStore((state) => state.bibleVersion);
+  const [verses, setVerses] = useState<{ verse: number; text: string }[]>([]);
+
+  useEffect(() => {
+    getVersesInChapter(activeBook, activeChapter, bibleVersion)
+      .then((result) => setVerses(result))
+      .catch((error) => console.error(error));
+  }, [activeBook, activeChapter, bibleVersion]);
+
   return (
     <Box style={{ flex: "1 0 100%" }}>
       <SubHeader open={open} />
@@ -21,11 +30,9 @@ const Passage = ({ open }: { open: () => void  }) => {
         h="80vh"
       >
         <ScrollArea h="80vh" viewportRef={viewport}>
-          {getVersesInChapter(activeBook, activeChapter).map(
-            ({ verse, text }) => (
-              <Verse verse={verse} key={verse} text={text} />
-            )
-          )}
+          {verses.map((verse) => (
+            <Verse verse={verse.verse} key={verse.verse} text={verse.text} />
+          ))}
         </ScrollArea>
       </Box>
     </Box>

--- a/src/components/PassageView.tsx
+++ b/src/components/PassageView.tsx
@@ -1,0 +1,44 @@
+import { useState, useEffect } from "react";
+import { ScrollArea, Center, Loader } from "@mantine/core";
+import { useBibleStore } from "../store";
+import { getVersesInChapter } from "../api";
+import Verse from "./Verse";
+
+const PassageView = () => {
+  const activeBook = useBibleStore((state) => state.activeBook);
+  const activeChapter = useBibleStore((state) => state.activeChapter);
+  const bibleVersion = useBibleStore((state) => state.bibleVersion);
+  const [verses, setVerses] = useState<{ verse: number; text: string }[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    getVersesInChapter(activeBook, activeChapter, bibleVersion)
+      .then((result) => {
+        setVerses(result);
+        setLoading(false);
+      })
+      .catch((error) => {
+        console.error(error);
+        setLoading(false);
+      });
+  }, [activeBook, activeChapter, bibleVersion]);
+
+  if (loading) {
+    return (
+      <Center h="80vh">
+        <Loader size="lg" />
+      </Center>
+    );
+  }
+
+  return (
+    <ScrollArea h="80vh">
+      {verses.map((verse) => (
+        <Verse verse={verse.verse} key={verse.verse} text={verse.text} />
+      ))}
+    </ScrollArea>
+  );
+};
+
+export default PassageView;

--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -48,7 +48,7 @@ export function SearchModal({
   const setActiveBook = useBibleStore((state) => state.setActiveBook);
   const setActiveBookShort = useBibleStore((state) => state.setActiveBookShort);
   const setActiveChapter = useBibleStore((state) => state.setActiveChapter);
-  const setActiveVerse = useBibleStore((state) => state.setActiveVerse);
+  const setActiveVerses = useBibleStore((state) => state.setActiveVerses);
 
   return (
     <Modal
@@ -81,7 +81,7 @@ export function SearchModal({
           setActiveBook(item.book_name);
           setActiveBookShort(item.book_id);
           setActiveChapter(item.chapter);
-          setActiveVerse(item.verse);
+          setActiveVerses([item.verse]);
           close();
         }}
       />

--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -11,9 +11,10 @@ import {
   SelectItemProps,
 } from "@mantine/core";
 import { useBibleStore } from "../store";
-import { Book, data } from "../api";
+import { data } from "../api";
+import { KjvBook } from '../api';
 
-const searchData = data.map((book: Book) => ({ ...book, value: book.text }));
+const searchData = data.map((book: KjvBook) => ({ ...book, value: book.text }));
 interface ItemProps extends SelectItemProps {
   chapter: number;
   verse: number;

--- a/src/components/SubHeader.tsx
+++ b/src/components/SubHeader.tsx
@@ -1,11 +1,10 @@
 import { ActionIcon, Box, Title, rem } from "@mantine/core";
-import {
-  IconArrowLeft,
-  IconArrowRight,
-  IconSearch,
-} from "@tabler/icons-react";
+import { IconArrowLeft, IconArrowRight, IconSearch } from "@tabler/icons-react";
+import { Button } from "@mantine/core";
 import { useBibleStore } from "../store";
+import { useState } from "react";
 import { getPassage } from "../api";
+import AddTagNoteModal from "./AddTagNoteModal";
 import Audio from "./Audio";
 
 const SubHeader = ({ open }: { open: () => void }) => {
@@ -16,6 +15,7 @@ const SubHeader = ({ open }: { open: () => void }) => {
   const setActiveBookShort = useBibleStore((state) => state.setActiveBookShort);
   const setActiveChapter = useBibleStore((state) => state.setActiveChapter);
   const getPassageResult = getPassage();
+  const [opened, setOpened] = useState(false);
   const checkNext = (): number | null => {
     const index = getPassageResult.findIndex(
       (book) => book.book_name === activeBook && book.chapter === activeChapter
@@ -77,6 +77,23 @@ const SubHeader = ({ open }: { open: () => void }) => {
       <Title order={4}>
         {activeBookShort} {activeChapter}
       </Title>
+      <Button
+        variant="transparent"
+        onClick={() =>
+          window.open(
+            "https://bible-research.vercel.app/api/v1/notes/",
+            "_blank"
+          )
+        }
+      >
+        Notes
+      </Button>
+      <Button variant="transparent" onClick={() => setOpened(true)}>
+        Add Note
+      </Button>
+      {opened && (
+        <AddTagNoteModal opened={opened} onClose={() => setOpened(false)} />
+      )}
       <Audio />
       <ActionIcon
         variant="transparent"

--- a/src/components/SubHeader.tsx
+++ b/src/components/SubHeader.tsx
@@ -7,7 +7,13 @@ import { getPassage } from "../api";
 import AddTagNoteModal from "./AddTagNoteModal";
 import Audio from "./Audio";
 
-const SubHeader = ({ open }: { open: () => void }) => {
+interface SubHeaderProps {
+  open: () => void;
+  showNotes: boolean;
+  setShowNotes: (show: boolean) => void;
+}
+
+const SubHeader = ({ open, showNotes, setShowNotes }: SubHeaderProps) => {
   const activeChapter = useBibleStore((state) => state.activeChapter);
   const activeBookShort = useBibleStore((state) => state.activeBookShort);
   const activeBook = useBibleStore((state) => state.activeBook);
@@ -79,14 +85,9 @@ const SubHeader = ({ open }: { open: () => void }) => {
       </Title>
       <Button
         variant="transparent"
-        onClick={() =>
-          window.open(
-            "https://bible-research.vercel.app/api/v1/notes/",
-            "_blank"
-          )
-        }
+        onClick={() => setShowNotes(!showNotes)}
       >
-        Notes
+        {showNotes ? "Bible" : "Notes"}
       </Button>
       <Button variant="transparent" onClick={() => setOpened(true)}>
         Add Note

--- a/src/components/TagSection.tsx
+++ b/src/components/TagSection.tsx
@@ -1,0 +1,24 @@
+import { Title, Stack } from "@mantine/core";
+import { Note } from "../api";
+import NoteCard from "./NoteCard";
+
+interface TagSectionProps {
+  tagName: string;
+  notes: Note[];
+  onViewInBible: (book: string, chapter: number, verse: number) => void;
+}
+
+const TagSection = ({ tagName, notes, onViewInBible }: TagSectionProps) => {
+  return (
+    <Stack spacing="md" mb={30}>
+      <Title order={2} mb={5}>
+        {tagName}
+      </Title>
+      {notes.map((note) => (
+        <NoteCard key={note.id} note={note} onViewInBible={onViewInBible} />
+      ))}
+    </Stack>
+  );
+};
+
+export default TagSection;

--- a/src/components/Verse.tsx
+++ b/src/components/Verse.tsx
@@ -1,6 +1,6 @@
 import { Box, Text, Title, createStyles } from "@mantine/core";
 import { useBibleStore } from "../store";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 
 const useStyles = createStyles((theme) => ({
   link: {
@@ -26,23 +26,36 @@ const useStyles = createStyles((theme) => ({
 const Verse = ({ verse, text }: { verse: number; text: string }) => {
   const ref = useRef<HTMLDivElement>(null);
   const { classes, cx } = useStyles();
-  const activeVerse = useBibleStore((state) => state.activeVerse);
-  const setActiveVerse = useBibleStore((state) => state.setActiveVerse);
-  setTimeout(() => {
-    ref.current?.scrollIntoView({ block: "center", behavior: "smooth" });
-  }, 1000);
+  const activeVerses = useBibleStore((state) => state.activeVerses);
+  const setActiveVerses = useBibleStore((state) => state.setActiveVerses);
+  const isActive = activeVerses.includes(verse);
+
+  const handleVerseClick = () => {
+    if (isActive) {
+      setActiveVerses(activeVerses.filter((v) => v !== verse));
+    } else {
+      setActiveVerses([...activeVerses, verse]);
+    }
+  };
+
+  useEffect(() => {
+    if (isActive) {
+      ref.current?.scrollIntoView({ block: "center", behavior: "smooth" });
+    }
+  }, [isActive]);
+
   return (
     <Box
       component="div"
       display="flex"
       className={cx(classes.link, {
-        [classes.linkActive]: activeVerse === verse,
+        [classes.linkActive]: isActive,
       })}
       py={7}
       px={10}
-      onClick={() => setActiveVerse(verse)}
+      onClick={handleVerseClick}
       id={"verse-" + verse}
-      ref={activeVerse === verse ? ref : null}
+      ref={isActive ? ref : null}
     >
       <Text fz="sm" fw="bold" mr={3}>
         {verse}

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -5,12 +5,13 @@ interface BibleState {
   activeBook: string;
   activeBookShort: string;
   activeChapter: number;
-  activeVerse: number;
+  activeVerses: number[];
   setActiveBook: (activeBook: string) => void;
   setActiveBookOnly: (activeBook: string) => void;
   setActiveBookShort: (activeBookShort: string) => void;
   setActiveChapter: (activeChapter: number) => void;
-  setActiveVerse: (activeVerse: number) => void;
+  setActiveVerses: (activeVerses: number[]) => void;
+  selectedVerses: number[];
 }
 
 export const useBibleStore = create<BibleState>()(
@@ -19,16 +20,19 @@ export const useBibleStore = create<BibleState>()(
       activeBook: "Genesis",
       activeBookShort: "Gen",
       activeChapter: 1,
-      activeVerse: 1,
+      activeVerses: [1],
+      selectedVerses: [],
       setActiveBook: (activeBook) => set({ activeBook, activeChapter: 1 }),
       setActiveBookOnly: (activeBook) => set({ activeBook }),
       setActiveBookShort: (activeBookShort) => set({ activeBookShort }),
       setActiveChapter: (activeChapter) => set({ activeChapter }),
-      setActiveVerse: (activeVerse) => {
-        set({ activeVerse });
-        document
-          .getElementById("verse-" + activeVerse)
-          ?.scrollIntoView({ block: "center", behavior: "smooth" });
+      setActiveVerses: (activeVerses) => {
+        set({ activeVerses });
+        activeVerses.forEach((verse) => {
+          document
+            .getElementById("verse-" + verse)
+            ?.scrollIntoView({ block: "center", behavior: "smooth" });
+        });
       },
     }),
     {

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -6,12 +6,14 @@ interface BibleState {
   activeBookShort: string;
   activeChapter: number;
   activeVerses: number[];
+  bibleVersion: string;
   setActiveBook: (activeBook: string) => void;
   setActiveBookOnly: (activeBook: string) => void;
   setActiveBookShort: (activeBookShort: string) => void;
   setActiveChapter: (activeChapter: number) => void;
   setActiveVerses: (activeVerses: number[]) => void;
   selectedVerses: number[];
+  setBibleVersion: (bibleVersion: string) => void;
 }
 
 export const useBibleStore = create<BibleState>()(
@@ -22,6 +24,7 @@ export const useBibleStore = create<BibleState>()(
       activeChapter: 1,
       activeVerses: [1],
       selectedVerses: [],
+      bibleVersion: "KJV",
       setActiveBook: (activeBook) => set({ activeBook, activeChapter: 1 }),
       setActiveBookOnly: (activeBook) => set({ activeBook }),
       setActiveBookShort: (activeBookShort) => set({ activeBookShort }),
@@ -34,6 +37,7 @@ export const useBibleStore = create<BibleState>()(
             ?.scrollIntoView({ block: "center", behavior: "smooth" });
         });
       },
+      setBibleVersion: (bibleVersion) => set({ bibleVersion }),
     }),
     {
       name: "bible-storage",


### PR DESCRIPTION
## Summary
Enables continuous Bible audio playback by automatically advancing to the next chapter when the current chapter's audio finishes. Users can now listen to multiple chapters or even the entire Bible without manual intervention.

## Feature Description

When audio playback reaches the end of a chapter:
1. App automatically navigates to the next chapter
2. Audio starts playing immediately on the new chapter
3. Continues until user manually stops or reaches the end of the Bible
4. Seamlessly transitions between books (e.g., Genesis 50 → Exodus 1)

## Changes

### Audio Component (`src/components/Audio.tsx`)

**Added Navigation Logic:**
- Imported `getPassage()` to access sequential chapter list
- Added Zustand store setters: `setActiveBookOnly`, `setActiveBookShort`, `setActiveChapter`
- Created `goToNextChapter()` function that:
  - Finds current chapter in the passage list
  - Navigates to the next chapter
  - Returns `true` if successful, `false` if at end of Bible

**Modified Audio End Behavior:**
```typescript
onend: () => {
  // When audio ends, try to go to next chapter
  const movedToNext = goToNextChapter();
  if (movedToNext) {
    // Keep playing on next chapter
    // isPlaying stays true, useEffect will trigger new audio
  } else {
    // No next chapter, stop playing
    setIsPlaying(false);
  }
}
```

## How It Works

### Automatic Continuation
1. Audio finishes naturally (reaches end)
2. `onend` callback fires
3. `goToNextChapter()` updates store with next book/chapter
4. `useEffect` detects change in `activeBook`/`activeChapter`
5. Since `isPlaying` is still `true`, new audio loads and plays automatically
6. Process repeats until end of Bible or user stops

### Smart Detection
- Only advances on natural audio end (not when user clicks stop)
- Handles book transitions automatically
- Stops gracefully at Revelation 22 (last chapter)

## User Experience

### Continuous Listening
**Before:**
- User plays Genesis 1
- Audio finishes
- User must manually click next chapter
- User must manually click play again
- Repeat for each chapter

**After:**
- User plays Genesis 1
- Audio finishes → Auto-advances to Genesis 2 → Plays automatically
- Continues through Genesis 3, 4, 5... without intervention
- User can listen to entire books or the whole Bible continuously

### Use Cases
1. **Devotional Listening**: Listen to multiple chapters during quiet time
2. **Commute/Exercise**: Hands-free continuous playback
3. **Bible Study**: Listen to entire books for context
4. **Bedtime Listening**: Fall asleep to continuous scripture

## Edge Cases Handled

### End of Bible
- When Revelation 22 finishes, audio stops (no next chapter)
- Play button reappears for user to restart if desired

### Manual Stop
- User clicks stop button → Audio stops immediately
- No auto-advance (only happens on natural end)
- User maintains full control

### Book Transitions
- Genesis 50 → Exodus 1 (seamless)
- Malachi 4 → Matthew 1 (seamless)
- All book boundaries handled automatically

### Error Handling
- If next chapter audio fails to load, playback stops
- Error message displayed to user
- No infinite loop or stuck state

## Technical Details

### Dependencies
The `useEffect` hook monitors:
```typescript
[activeBook, activeChapter, bibleVersion, isPlaying]
```

When `activeBook` or `activeChapter` changes while `isPlaying=true`:
- Previous audio is stopped and unloaded
- New audio URL is fetched
- New audio loads and plays automatically

### Navigation Logic
Uses the same `getPassage()` function as the next/previous chapter buttons:
- Maintains consistency with existing navigation
- Respects the same chapter ordering
- Handles all 1,189 Bible chapters

## Testing

- ✅ TypeScript compilation successful
- ✅ Build successful
- ⏳ Manual testing recommended:
  - Play Genesis 1, verify auto-advance to Genesis 2
  - Let play through multiple chapters
  - Verify book transitions (Genesis 50 → Exodus 1)
  - Click stop mid-playback, verify it stops
  - Verify stops at Revelation 22
  - Test with KJV (all books)
  - Test with ESV (Old Testament only)

## Statistics
- **1 file changed**
- **41 insertions(+)**
- **2 deletions(-)**
- **1 commit**

## Breaking Changes
None. Existing audio functionality preserved. Users can still:
- Play/stop audio manually
- Navigate chapters manually
- Use next/previous buttons

## Future Enhancements
Potential follow-ups:
- Add toggle to enable/disable auto-advance
- Add "Play from here to end of book" button
- Add playlist feature (select chapters to play)
- Add speed control (0.75x, 1x, 1.25x, 1.5x)
- Add sleep timer (stop after X minutes)
- Show progress indicator (Chapter 3 of 50)